### PR TITLE
Ask CGI to not warn about param() in list context.

### DIFF
--- a/lib/HTML/Mason/Utils.pm
+++ b/lib/HTML/Mason/Utils.pm
@@ -42,6 +42,7 @@ sub cgi_request_args
 
     foreach my $key ( map { $q->$_() } @methods ) {
         next if exists $args{$key};
+        local $CGI::LIST_CONTEXT_WARN = 0;
         my @values = map { $q->$_($key) } @methods;
         $args{$key} = @values == 1 ? $values[0] : \@values;
     }

--- a/t/14-cgi.t
+++ b/t/14-cgi.t
@@ -29,7 +29,7 @@ use CGI qw(-no_debug);  # Prevent "(offline mode: enter name=value pairs on stan
              %interp_params,
             );
         
-        eval { $self->_execute($interp) };
+        eval { local $CGI::LIST_CONTEXT_WARN = 0; $self->_execute($interp) };
         
         return $self->check_result($@);
     }


### PR DESCRIPTION
Mason protects from the class of param() bugs which allow users to sneak in
arguments as described here:
http://blog.gerv.net/2014/10/new-class-of-vulnerability-in-perl-web-applications/

Since CGI.pm 4.05 the only way to quiet this warning is by setting their
variable as documented here
https://metacpan.org/pod/CGI#Fetching-the-value-or-values-of-a-single-named-parameter

Mason has always allowed foo=1&foo=2 to end up available in a template
as @foo = (1,2) so retain backcompat.

Quiets a warning in t/14-cgi.t tied to faking up CGI.pm

Reported in https://rt.cpan.org/Ticket/Display.html?id=99520
