### PR TITLE
Fix t/13-errors.t failing w/o '.' in @INC

### DIFF
--- a/t/13-errors.t
+++ b/t/13-errors.t
@@ -417,7 +417,7 @@ EOF
                       description => 'Require a module with an error in a once block',
                       component => <<'EOF',
 <%once>
-require "t/lib/BadModule.pm";
+require "./t/lib/BadModule.pm";
 </%once>
 hi!
 EOF


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/616966
Bug: https://rt.cpan.org/Public/Bug/Display.html?id=121443