### PR TITLE
fixed $m leaking when using <%shared>

### DIFF
--- a/lib/HTML/Mason/Request.pm
+++ b/lib/HTML/Mason/Request.pm
@@ -943,6 +943,7 @@ sub call_dynamic {
     if (!defined($comp->dynamic_subs_request) or $comp->dynamic_subs_request ne $m) {
         $comp->dynamic_subs_init;
         $comp->dynamic_subs_request($m);
+        Scalar::Util::weaken( $comp->{dynamic_subs_request} ) if can_weaken;
     }
 
     return $comp->run_dynamic_sub($key, @args);

--- a/t/26-leak-with-shared.t
+++ b/t/26-leak-with-shared.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+
+use HTML::Mason::Tools qw(can_weaken);
+BEGIN
+{
+    unless ( can_weaken )
+    {
+        print "Your installation does not include Scalar::Util::weaken\n";
+        print "1..0\n";
+        exit;
+    }
+}
+
+use Test::More;
+
+use HTML::Mason::Interp;
+
+plan tests => 2;
+
+our $Destroyed = 0;
+
+SIMPLE_OBJECTS:
+{
+    $Destroyed = 0;
+    my $interp = HTML::Mason::Interp->new( out_method => sub {} );
+    my $comp = $interp->make_component( comp_source => 'Comp' );
+    $interp->exec( $comp, Object->new() );
+    is( $Destroyed, 1, 'object passed into request was destroyed' );
+}
+
+SIMPLE_OBJECTS_WITH_SHARED:
+{
+    $Destroyed = 0;
+    my $interp = HTML::Mason::Interp->new( out_method => sub {} );
+    my $comp = $interp->make_component( comp_source => 'Comp<%shared></%shared>' );
+    $interp->exec( $comp, Object->new() );
+    is( $Destroyed, 1, 'object passed into request was destroyed with shared' );
+}
+
+package Object;
+
+sub new { return bless {}, $_[0] }
+
+sub DESTROY { $Destroyed++ }
+
+sub DestroyCount { $Destroyed }


### PR DESCRIPTION
<%shared> is certainly a bit complicated.
https://github.com/stevan/p5-HTML-MasonX-Critic/blob/0ee02c72e94431e8c4b4377898e4ffe8685a7823/lib/HTML/MasonX/Critic/Policy/Blocks/ProhibitSharedBlocks.pm#L14

But as much as I understand and use, I hope it works.