### PR TITLE
Relax test expectation

### DIFF
--- a/t/13-errors.t
+++ b/t/13-errors.t
@@ -343,10 +343,8 @@ EOF
                       component => <<'EOF',
 % my $x = 
 EOF
-                        # match "Error during compilation" followed by 
-                        # exactly one occurance of "Stack:"
-                        # (Mason should stop after the first error)
-                      expect => qr/Error during compilation((?!Stack:).)*Stack:((?!Stack:).)*$/s,
+                      # match "Error during compilation"
+                      expect => qr/Error during compilation((?!Stack:).)*Stack:((?!Stack:).)*/s,
                     );
 
 #------------------------------------------------------------


### PR DESCRIPTION
To accommodate change in Perl 5 exception output.

For: https://github.com/houseabsolute/HTML-Mason/issues/33