### PR TITLE
Ignore files created by 'perl Makefile.PL' or 'make'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /mason_tests
 /release
 /tmp
+/MYMETA.*
+/Makefile
+/blib/
+/pm_to_blib


### PR DESCRIPTION
These files and directories do not need to be stored in the repository or tracked by git, so can be added to .gitignore for better results in 'git status'.